### PR TITLE
Idiomatic reducers

### DIFF
--- a/client/components/NotebookCell/NotebookCell.jsx
+++ b/client/components/NotebookCell/NotebookCell.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
+import { getCellById } from 'app/reducers'
+
 class NotebookCell extends React.Component {
   render() {
     const { data, type, error } = this.props
@@ -15,8 +17,8 @@ class NotebookCell extends React.Component {
   }
 }
 
-const mapStateToProps = ({ cellsById }, { id }) => {
-  return cellsById[id] || { error: `No cell with id ${id}` }
+const mapStateToProps = (state, { id }) => {
+  return getCellById(state, id)
 }
 
 export default connect(mapStateToProps)(NotebookCell)

--- a/client/reducers/cellIds.es6
+++ b/client/reducers/cellIds.es6
@@ -1,0 +1,13 @@
+import _ from 'lodash'
+
+import { CREATE_CELL } from 'app/actions'
+import { cells } from 'app/dummyData'
+
+export default (state=_.map(cells, cell => cell.id), action) => {
+  switch (action.type) {
+    case CREATE_CELL:
+      return state.concat(action.cell.id)
+    default:
+      return state
+  }
+}

--- a/client/reducers/cellsById.es6
+++ b/client/reducers/cellsById.es6
@@ -1,0 +1,20 @@
+import _ from 'lodash'
+
+import { CREATE_CELL } from 'app/actions'
+import { cells } from 'app/dummyData'
+
+export default (state=_.keyBy(cells, 'id'), action) => {
+  switch (action.type) {
+    case CREATE_CELL:
+      return {
+        ...state,
+        [action.cell.id]: action.cell,
+      }
+    default:
+      return state
+  }
+}
+
+export const getCellById = (state, id) => {
+	return state[id] || { error: `No cell with id ${id}` }
+}

--- a/client/reducers/index.js
+++ b/client/reducers/index.js
@@ -1,31 +1,14 @@
 import _ from 'lodash'
 import { combineReducers } from 'redux'
 
-import { cells } from 'app/dummyData'
-import { CREATE_CELL } from 'app/actions'
-
-const cellsById = (state=_.keyBy(cells, 'id'), action) => {
-  switch (action.type) {
-    case CREATE_CELL:
-      return {
-        ...state,
-        [action.cell.id]: action.cell,
-      }
-    default:
-      return state
-  }
-}
-
-const cellIds = (state=_.map(cells, cell => cell.id), action) => {
-  switch (action.type) {
-    case CREATE_CELL:
-      return state.concat(action.cell.id)
-    default:
-      return state
-  }
-}
+import cellsById, * as fromCellsById from './cellsById'
+import cellIds from './cellIds'
 
 export const appReducer = combineReducers({
   cellsById,
   cellIds,
 })
+
+export const getCellById = (state, id) => {
+  return fromCellsById.getCellById(state.cellsById, id)
+}


### PR DESCRIPTION
Move the reducers into their own files
Move the `getCellById` selector into the `cellsById` reducer file
